### PR TITLE
feat: better support for XDG Base Directory

### DIFF
--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -10,19 +10,22 @@ import os
 from configparser import ConfigParser
 from pathlib import Path
 
+import gi
+
+gi.require_version("GLib", "2.0")
+from gi.repository import GLib
+
 
 class UserSettings(object):
     def __init__(self):
-        self.xdg_config_dir = os.getenv("XDG_CONFIG_HOME", str(Path.home()) + "/.config/")
-
         self.default_status = False
         self.default_temp = 5500
         self.default_autostart = False
 
-        self.configdir = self.xdg_config_dir + "/pardus/pardus-night-light/"
+        self.configdir = "{}/pardus/pardus-night-light/".format(GLib.get_user_config_dir())
         self.configfile = "settings.ini"
 
-        self.autostartdir = self.xdg_config_dir + "/autostart/"
+        self.autostartdir = "{}/autostart/".format(GLib.get_user_config_dir())
         self.autostartfile = "tr.org.pardus.night-light-autostart.desktop"
 
         self.config = ConfigParser(strict=False)

--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -13,16 +13,16 @@ from pathlib import Path
 
 class UserSettings(object):
     def __init__(self):
-        self.userhome = str(Path.home())
+        self.xdg_config_dir = os.getenv("XDG_CONFIG_HOME", str(Path.home()) + "/.config/")
 
         self.default_status = False
         self.default_temp = 5500
         self.default_autostart = False
 
-        self.configdir = self.userhome + "/.config/pardus/pardus-night-light/"
+        self.configdir = self.xdg_config_dir + "/pardus/pardus-night-light/"
         self.configfile = "settings.ini"
 
-        self.autostartdir = self.userhome + "/.config/autostart/"
+        self.autostartdir = self.xdg_config_dir + "/autostart/"
         self.autostartfile = "tr.org.pardus.night-light-autostart.desktop"
 
         self.config = ConfigParser(strict=False)


### PR DESCRIPTION
This PR removes the hardcoded path for the user configuration directory (`$HOME/.config/`) and instead uses the environment variable XDG_CONFIG_HOME. This allows users to have more control over where the configuration files are stored.