### PR TITLE
Add a warning for wayland users

### DIFF
--- a/po/pardus-night-light.pot
+++ b/po/pardus-night-light.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-15 00:57+0300\n"
+"POT-Creation-Date: 2025-05-30 21:02+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Launch at startup"
 msgstr ""
 
-#: ui/MainWindow.glade:238 src/MainWindow.py:58 src/MainWindow.py:265
+#: ui/MainWindow.glade:238 src/MainWindow.py:59 src/MainWindow.py:264
 msgid "Pardus Night Light"
 msgstr ""
 
@@ -42,38 +42,49 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: src/MainWindow.py:62
+#: src/MainWindow.py:63
 msgid "About Pardus Night Light"
 msgstr ""
 
-#: src/MainWindow.py:216
+#: src/MainWindow.py:215
 msgid "Low"
 msgstr ""
 
-#: src/MainWindow.py:233
+#: src/MainWindow.py:232
 msgid "Medium"
 msgstr ""
 
-#: src/MainWindow.py:250
+#: src/MainWindow.py:249
 msgid "High"
 msgstr ""
 
-#: src/MainWindow.py:273
+#: src/MainWindow.py:272
 msgid "Quit"
 msgstr ""
 
-#: src/MainWindow.py:285 src/MainWindow.py:402
+#: src/MainWindow.py:284 src/MainWindow.py:401
 msgid "Disable"
 msgstr ""
 
-#: src/MainWindow.py:288 src/MainWindow.py:406
+#: src/MainWindow.py:287 src/MainWindow.py:405
 msgid "Enable"
 msgstr ""
 
-#: src/MainWindow.py:292 src/MainWindow.py:309
+#: src/MainWindow.py:291 src/MainWindow.py:308
 msgid "Hide App"
 msgstr ""
 
-#: src/MainWindow.py:294 src/MainWindow.py:306 src/MainWindow.py:428
+#: src/MainWindow.py:293 src/MainWindow.py:305 src/MainWindow.py:427
 msgid "Show App"
+msgstr ""
+
+#: src/MainWindow.py:448
+msgid "Wayland Compatibility Warning"
+msgstr ""
+
+#: src/MainWindow.py:452
+msgid ""
+"This application is based on Redshift, which does not work properly on "
+"Wayland. For best functionality, please use an X11 session or consider using "
+"your desktop environment's night light feature."
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-19 10:35+0300\n"
+"POT-Creation-Date: 2025-05-30 21:02+0300\n"
 "PO-Revision-Date: 2024-03-20 18:31+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: \n"
@@ -30,42 +30,65 @@ msgstr "Temperatura da cor"
 msgid "Launch at startup"
 msgstr "Iniciar no arranque"
 
-#: ui/MainWindow.glade:208 src/MainWindow.py:57 src/MainWindow.py:133
+#: ui/MainWindow.glade:238 src/MainWindow.py:59 src/MainWindow.py:264
 msgid "Pardus Night Light"
 msgstr "Luz Noturna Pardus"
 
-#: ui/MainWindow.glade:237
+#: ui/MainWindow.glade:267
 msgid "Simple color temperature application based on Redshift."
 msgstr "Aplicação para ajustar a temperatura da cor baseada no Redshift."
 
 #. Name Surname <example@examplemail.com>
-#: ui/MainWindow.glade:240
+#: ui/MainWindow.glade:270
 msgid "translator-credits"
 msgstr "Hugo Carvalho <hugokarvalho@hotmail.com>"
 
-#: src/MainWindow.py:61
+#: src/MainWindow.py:63
 msgid "About Pardus Night Light"
 msgstr "Acerca do Luz Noturna Pardus"
 
-#: src/MainWindow.py:141
+#: src/MainWindow.py:215
+msgid "Low"
+msgstr ""
+
+#: src/MainWindow.py:232
+msgid "Medium"
+msgstr ""
+
+#: src/MainWindow.py:249
+msgid "High"
+msgstr ""
+
+#: src/MainWindow.py:272
 msgid "Quit"
 msgstr "Sair"
 
-#: src/MainWindow.py:153 src/MainWindow.py:203
+#: src/MainWindow.py:284 src/MainWindow.py:401
 msgid "Disable"
 msgstr "Desativar"
 
-#: src/MainWindow.py:156 src/MainWindow.py:207
+#: src/MainWindow.py:287 src/MainWindow.py:405
 msgid "Enable"
 msgstr "Ativar"
 
-#: src/MainWindow.py:160 src/MainWindow.py:177
+#: src/MainWindow.py:291 src/MainWindow.py:308
 msgid "Hide App"
 msgstr "Ocultar aplicação"
 
-#: src/MainWindow.py:162 src/MainWindow.py:174 src/MainWindow.py:230
+#: src/MainWindow.py:293 src/MainWindow.py:305 src/MainWindow.py:427
 msgid "Show App"
 msgstr "Mostrar aplicação"
+
+#: src/MainWindow.py:448
+msgid "Wayland Compatibility Warning"
+msgstr ""
+
+#: src/MainWindow.py:452
+msgid ""
+"This application is based on Redshift, which does not work properly on "
+"Wayland. For best functionality, please use an X11 session or consider using "
+"your desktop environment's night light feature."
+msgstr ""
 
 #~ msgid "Based on Redshift"
 #~ msgstr "Baseada no Redshift"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,15 +9,15 @@ msgstr ""
 "Project-Id-Version: 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-05-30 21:02+0300\n"
-"PO-Revision-Date: 2025-04-15 00:58+0300\n"
-"Last-Translator: Fatih Altun <fatih.altun@pardus.org.tr>\n"
+"PO-Revision-Date: 2025-05-30 21:09+0300\n"
+"Last-Translator: Edip Hazuri <edip@medip.dev>\n"
 "Language-Team: Turkish <dev@pardus.org.tr>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0\n"
-"X-Generator: Gtranslator 42.0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.6\n"
 
 #: ui/MainWindow.glade:51
 msgid "Night Light"
@@ -82,7 +82,7 @@ msgstr "Göster"
 
 #: src/MainWindow.py:448
 msgid "Wayland Compatibility Warning"
-msgstr ""
+msgstr "Wayland Uyumluluk Uyarısı"
 
 #: src/MainWindow.py:452
 msgid ""
@@ -90,6 +90,9 @@ msgid ""
 "Wayland. For best functionality, please use an X11 session or consider using "
 "your desktop environment's night light feature."
 msgstr ""
+"Bu uygulama Redshift tabanlı olduğundan Waylandda düzgün çalışmamaktadır. En "
+"iyi deneyim için, Lütfen X11 oturumuna geçin veya masaüstü ortamınızın gece "
+"ışığı özelliğini kullanın."
 
 #~ msgid "Based on Redshift"
 #~ msgstr "Redshift tabanlı"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-15 00:57+0300\n"
+"POT-Creation-Date: 2025-05-30 21:02+0300\n"
 "PO-Revision-Date: 2025-04-15 00:58+0300\n"
 "Last-Translator: Fatih Altun <fatih.altun@pardus.org.tr>\n"
 "Language-Team: Turkish <dev@pardus.org.tr>\n"
@@ -31,7 +31,7 @@ msgstr "Renk Sıcaklığı"
 msgid "Launch at startup"
 msgstr "Başlangıçta çalıştır"
 
-#: ui/MainWindow.glade:238 src/MainWindow.py:58 src/MainWindow.py:265
+#: ui/MainWindow.glade:238 src/MainWindow.py:59 src/MainWindow.py:264
 msgid "Pardus Night Light"
 msgstr "Pardus Gece Işığı"
 
@@ -44,41 +44,52 @@ msgstr "Redshift tabanlı basit renk sıcaklığı uygulaması."
 msgid "translator-credits"
 msgstr "Fatih Altun <fatih.altun@pardus.org.tr>"
 
-#: src/MainWindow.py:62
+#: src/MainWindow.py:63
 msgid "About Pardus Night Light"
 msgstr "Pardus Gece Işığı Hakkında"
 
-#: src/MainWindow.py:216
+#: src/MainWindow.py:215
 msgid "Low"
 msgstr "Düşük"
 
-#: src/MainWindow.py:233
+#: src/MainWindow.py:232
 msgid "Medium"
 msgstr "Orta"
 
-#: src/MainWindow.py:250
+#: src/MainWindow.py:249
 msgid "High"
 msgstr "Yüksek"
 
-#: src/MainWindow.py:273
+#: src/MainWindow.py:272
 msgid "Quit"
 msgstr "Çıkış"
 
-#: src/MainWindow.py:285 src/MainWindow.py:402
+#: src/MainWindow.py:284 src/MainWindow.py:401
 msgid "Disable"
 msgstr "Devre Dışı Bırak"
 
-#: src/MainWindow.py:288 src/MainWindow.py:406
+#: src/MainWindow.py:287 src/MainWindow.py:405
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/MainWindow.py:292 src/MainWindow.py:309
+#: src/MainWindow.py:291 src/MainWindow.py:308
 msgid "Hide App"
 msgstr "Gizle"
 
-#: src/MainWindow.py:294 src/MainWindow.py:306 src/MainWindow.py:428
+#: src/MainWindow.py:293 src/MainWindow.py:305 src/MainWindow.py:427
 msgid "Show App"
 msgstr "Göster"
+
+#: src/MainWindow.py:448
+msgid "Wayland Compatibility Warning"
+msgstr ""
+
+#: src/MainWindow.py:452
+msgid ""
+"This application is based on Redshift, which does not work properly on "
+"Wayland. For best functionality, please use an X11 session or consider using "
+"your desktop environment's night light feature."
+msgstr ""
 
 #~ msgid "Based on Redshift"
 #~ msgstr "Redshift tabanlı"

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -50,6 +50,7 @@ class MainWindow(object):
         self.define_variables()
         self.main_window.set_application(application)
 
+        self.check_wayland_and_warn()
         self.user_settings()
         self.set_autostart()
         self.init_indicator()
@@ -430,4 +431,28 @@ class MainWindow(object):
         subprocess.run(["redshift", "-x"])
         if self.about_dialog.is_visible():
             self.about_dialog.hide()
+        self.main_window.get_application().quit()
+
+    def check_wayland_and_warn(self):
+        wayland_display = os.environ.get('WAYLAND_DISPLAY')
+        xdg_session_type = os.environ.get('XDG_SESSION_TYPE')
+        
+        if not wayland_display or xdg_session_type != 'wayland':
+            return
+        
+        dialog = Gtk.MessageDialog(
+            parent=None,
+            flags=0,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.OK,
+            text=_("Wayland Compatibility Warning")
+        )
+        
+        dialog.format_secondary_text(
+            _("This application is based on Redshift, which does not work properly on Wayland. "
+              "For best functionality, please use an X11 session or consider using your desktop environment's night light feature.")
+        )
+        
+        dialog.run()
+        dialog.destroy()
         self.main_window.get_application().quit()


### PR DESCRIPTION
Redshift doesnt work properly on wayland. If a user would open the night light app under wayland it will just not work without giving any warning.
With this commits, the app will not open on wayland, instead it will just show a warning
![image](https://github.com/user-attachments/assets/993bcbd4-64d9-4ecc-a017-4916a5fbd178)
